### PR TITLE
Added handling of postgresql:// connect URI format

### DIFF
--- a/src/PqClient.js
+++ b/src/PqClient.js
@@ -218,8 +218,8 @@ var normalizeConnstr = function(connstr, password){
         if (meta_start != -1){
             connstr = connstr.substr(0, meta_start).trim();
         }
-        if (connstr.lastIndexOf('postgresql://', 0) !== 0) {
-            connstr = 'postgresql://'+connstr;
+        if (connstr.lastIndexOf('postgresql://', 0) !== 0 && connstr.lastIndexOf('postgres://', 0) !== 0) {
+            connstr = 'postgres://'+connstr;
             parsed = url.parse(connstr);
             if (parsed.query == null){
                 var params = "application_name=sqltabs";

--- a/src/PqClient.js
+++ b/src/PqClient.js
@@ -218,8 +218,8 @@ var normalizeConnstr = function(connstr, password){
         if (meta_start != -1){
             connstr = connstr.substr(0, meta_start).trim();
         }
-        if (connstr.lastIndexOf('postgres://', 0) !== 0) {
-            connstr = 'postgres://'+connstr;
+        if (connstr.lastIndexOf('postgresql://', 0) !== 0) {
+            connstr = 'postgresql://'+connstr;
             parsed = url.parse(connstr);
             if (parsed.query == null){
                 var params = "application_name=sqltabs";


### PR DESCRIPTION
There is no postgres:// connect URI format. Correct connection URI format is postgresql:// as in http://www.postgresql.org/docs/9.3/static/libpq-connect.html .