### PR TITLE
Fix typo on Mac version 'quit' command menu item.

### DIFF
--- a/src/Menu.js
+++ b/src/Menu.js
@@ -94,7 +94,7 @@ if (process.platform == 'darwin'){
             type: 'separator'
           },
           {
-            label: 'Quite',
+            label: 'Quit',
             accelerator: 'Command+Q',
             click: function(){app.quit()},
           },


### PR DESCRIPTION
Fix typo on Mac version's "quit" command menu item.

The Quit command is labeled as "Quite".  Update the label to "Quit".
