### PR TITLE
Option to filter schemas

### DIFF
--- a/src/Actions.js
+++ b/src/Actions.js
@@ -124,6 +124,13 @@ var Actions = {
         });
     },
 
+    setSchemaFilter: function (filter) {
+        AppDispatcher.dispatch({
+            eventName: 'set-schema-filter',
+            key: filter,
+        });
+    },
+
     setConnection: function(key, value){
         AppDispatcher.dispatch({
             eventName: 'set-connection',

--- a/src/Config.js
+++ b/src/Config.js
@@ -35,6 +35,15 @@ if (!db.object.config){
 var config = db.object.config;
 
 var Conf = {
+    saveSchemaFilter: function(schemaFilter){
+        config.schemaFilter = schemaFilter;
+        this.saveSync();
+    },
+
+    getSchemaFilter: function(){
+        return config.schemaFilter;
+    },
+
     saveTheme: function(theme){
         config.theme = theme;
         this.saveSync();

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -122,6 +122,12 @@ AppDispatcher.register( function(payload) {
             TabsStore.trigger('change-mode');
             break;
 
+        case 'set-schema-filter':
+            TabsStore.setSchemaFilter(payload.key);
+            Config.saveSchemaFilter(payload.key);
+            TabsStore.trigger('change-schema-filter');
+            break;
+
         case 'remove-connection-item':
             TabsStore.removeConnectionItem(payload.value);
             Config.saveConnHistory(TabsStore.connectionHistory);

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -238,6 +238,11 @@ if (process.platform == 'darwin'){
                 {label: "Echo on", click: function(){TabsStore.setEcho(true);}},
                 {label: "Echo off", click: function(){TabsStore.setEcho(false);}},
             ]},
+            {label: "Filter Schemas",
+            submenu: [
+                {label: "Filter on", click: function(){Actions.setSchemaFilter(true);}},
+                {label: "Filter off", click: function(){Actions.setSchemaFilter(false);}},
+            ]},
             {label: "Autocompletion",
             submenu: [
                 {label: "On", click: function(){TabsStore.setAutocompletion(true);}},

--- a/src/ObjectInfo.js
+++ b/src/ObjectInfo.js
@@ -39,6 +39,7 @@ var ObjectInfo = React.createClass({
     componentDidMount: function(){
 
         TabsStore.bind('change-theme', this.changeThemeHandler);
+        TabsStore.bind('change-schema-filter', this.changeSchemaFilter);
 
         if (this.scripts.length > 0){
 
@@ -71,6 +72,19 @@ var ObjectInfo = React.createClass({
         if (typeof(this.editor) != 'undefined'){
             this.editor.setTheme('ace/theme/' + TabsStore.getEditorTheme());
         }
+    },
+
+    changeSchemaFilter: function(){
+        if (this.props.info.object_type == 'database') {
+            this.forceUpdate();
+        }
+    },
+
+    filterSchemas: function(item){
+         if (TabsStore.schemaFilter) {
+             return item.indexOf('temp') === -1;
+         }
+         return true;
     },
 
     getInfo: function(object){
@@ -196,7 +210,7 @@ var ObjectInfo = React.createClass({
                     '#output-console-'+self.props.eventKey, "#output-console-"+self.props.eventKey
                     )}}><span className="glyphicon glyphicon-circle-arrow-up"/></a>;
 
-        var schemas = info.object.schemas.map(function(item, idx){
+        var schemas = info.object.schemas.filter(this.filterSchemas).map(function(item, idx){
             var id = "schema_"+self.props.eventKey+"_"+idx;
             return <li key={id}><a href="#" onClick={function(){self.getInfo(item+'.');}}>{item}</a></li>
         });

--- a/src/TabsStore.js
+++ b/src/TabsStore.js
@@ -162,6 +162,10 @@ var _TabsStore = function(){
         this.mode = mode;
     };
 
+    this.setSchemaFilter = function (schemaFilter) {
+        this.schemaFilter = schemaFilter;
+    },
+
     this.getEditorMode = function(){
         if (this.mode == 'vim'){
             return 'ace/keyboard/vim';


### PR DESCRIPTION
Sometimes the are too many schemas on a DB, and the extra schemas are recognisable by the presence of the text "temp".
This PR add a menu with an option to enable the schema filtering, that will filter out all the schemas containing "temp"

![screen shot 2017-03-14 at 13 35 44](https://cloud.githubusercontent.com/assets/4061875/23903191/9289d1ba-08bb-11e7-8cae-d0730871a34d.png)
![screen shot 2017-03-14 at 13 35 54](https://cloud.githubusercontent.com/assets/4061875/23903190/92899290-08bb-11e7-8488-2225ef6858e6.png)
