### PR TITLE
Feat/settings page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*
 .build
 node_modules/*
 sqltabs.dmg
+.idea

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
   },
   "scripts": {
     "postinstall": "rm -r node_modules/c3/node_modules; babel --plugins transform-react-jsx --out-dir=build src/",
+    "build:mac": "./mac_build.sh",
+    "build:win": "./win_build.sh",
+    "build:linux": "./linux_build.sh",
     "build-watch": "babel --plugins transform-react-jsx --out-dir=build src/ --watch"
   }
 }

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -92,10 +92,12 @@ var Actions = {
     },
 
     close: function(id){
-        AppDispatcher.dispatch({
-            eventName: 'close-tab',
-            key: id,
-        });
+        if (typeof id !== 'undefined' || window.confirm('Are you sure you want to close the current tab?')) {
+            AppDispatcher.dispatch({
+                eventName: 'close-tab',
+                key: id,
+            });
+        }
     },
 
     nextTab: function(){
@@ -336,6 +338,12 @@ var Actions = {
     showProject: function(){
         AppDispatcher.dispatch({
             eventName: 'show-project',
+        });
+    },
+
+    showSettings: function(){
+        AppDispatcher.dispatch({
+            eventName: 'show-settings',
         });
     },
 

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -124,6 +124,13 @@ var Actions = {
         });
     },
 
+    setSchemaFilter: function (filter) {
+        AppDispatcher.dispatch({
+            eventName: 'set-schema-filter',
+            key: filter,
+        });
+    },
+
     setConnection: function(key, value){
         AppDispatcher.dispatch({
             eventName: 'set-connection',

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -126,9 +126,9 @@ var Actions = {
         });
     },
 
-    setSchemaFilter: function (filter) {
+    enableSchemaFilter: function (filter) {
         AppDispatcher.dispatch({
-            eventName: 'set-schema-filter',
+            eventName: 'enable-schema-filter',
             key: filter,
         });
     },
@@ -244,6 +244,20 @@ var Actions = {
         AppDispatcher.dispatch({
             eventName: 'set-font-size',
             size: size,
+        });
+    },
+
+    setSchemaFilterMode: function(mode){
+        AppDispatcher.dispatch({
+            eventName: 'set-schema-filter-mode',
+            mode: mode,
+        });
+    },
+
+    setSchemaFilterRegEx: function(regex){
+        AppDispatcher.dispatch({
+            eventName: 'set-schema-filter-regex',
+            regex: regex,
         });
     },
 

--- a/src/App.js
+++ b/src/App.js
@@ -61,8 +61,16 @@ var app = <App/>;
 
 var theme = (Config.getTheme() || 'dark');
 var size = (Config.getFontSize() || 'medium');
+var schemaFilter = (Config.getSchemaFilter() || {
+    enabled: false,
+    mode: 'black',
+    regex: '.*temp.*',
+});
 Actions.setTheme(theme);
 Actions.setFontSize(size);
+Actions.enableSchemaFilter(schemaFilter.enabled);
+Actions.setSchemaFilterMode(schemaFilter.mode);
+Actions.setSchemaFilterRegEx(schemaFilter.regex);
 Actions.upgradeCheck();
 
 React.render(app, mountNode);

--- a/src/Config.js
+++ b/src/Config.js
@@ -35,6 +35,15 @@ if (!db.object.config){
 var config = db.object.config;
 
 var Conf = {
+    saveSchemaFilter: function(schemaFilter){
+        config.schemaFilter = schemaFilter;
+        this.saveSync();
+    },
+
+    getSchemaFilter: function(){
+        return config.schemaFilter;
+    },
+
     saveTheme: function(theme){
         config.theme = theme;
         this.saveSync();

--- a/src/Config.js
+++ b/src/Config.js
@@ -35,8 +35,8 @@ if (!db.object.config){
 var config = db.object.config;
 
 var Conf = {
-    saveSchemaFilter: function(schemaFilter){
-        config.schemaFilter = schemaFilter;
+    saveSchemaFilter: function(newProps){
+        config.schemaFilter = Object.assign({}, config.schemaFilter, newProps);
         this.saveSync();
     },
 

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -132,9 +132,27 @@ AppDispatcher.register( function(payload) {
             TabsStore.trigger('change-mode');
             break;
 
-        case 'set-schema-filter':
-            TabsStore.setSchemaFilter(payload.key);
-            Config.saveSchemaFilter(payload.key);
+        case 'enable-schema-filter':
+            TabsStore.enableSchemaFilter(payload.key);
+            Config.saveSchemaFilter({
+                enabled: payload.key
+            });
+            TabsStore.trigger('change-schema-filter');
+            break;
+
+        case 'set-schema-filter-mode':
+            TabsStore.setSchemaFilterMode(payload.mode);
+            Config.saveSchemaFilter({
+                mode: payload.mode
+            });
+            TabsStore.trigger('change-schema-filter');
+            break;
+
+        case 'set-schema-filter-regex':
+            TabsStore.setSchemaFilterRegex(payload.regex);
+            Config.saveSchemaFilter({
+                regex: payload.regex
+            });
             TabsStore.trigger('change-schema-filter');
             break;
 

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -122,6 +122,12 @@ AppDispatcher.register( function(payload) {
             TabsStore.trigger('change-mode');
             break;
 
+        case 'set-schema-filter':
+            TabsStore.setSchemaFilter(payload.key);
+            Config.saveSchemaFilter(payload.key);
+            TabsStore.trigger('change-schema-filter');
+            break;
+
         case 'remove-connection-item':
             TabsStore.removeConnectionItem(payload.value);
             Config.saveConnHistory(TabsStore.connectionHistory);

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -69,7 +69,12 @@ AppDispatcher.register( function(payload) {
     switch( payload.eventName ) {
         case 'show-settings':
             // Only one settings tab open at the time, so firstly search the open one
-            var tabId = TabsStore.newTab('about:settings');
+            var settingsTab = TabsStore.findIndexByProperty('connstr', 'about:settings')
+            if (settingsTab !== -1) {
+                TabsStore.selectTab(settingsTab)
+            } else {
+                TabsStore.newTab('about:settings');
+            }
             TabsStore.trigger('change');
             break;
         case 'select-tab':

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -67,6 +67,11 @@ SignalsDispatcher.register(function(payload){
 
 AppDispatcher.register( function(payload) {
     switch( payload.eventName ) {
+        case 'show-settings':
+            // Only one settings tab open at the time, so firstly search the open one
+            var tabId = TabsStore.newTab('about:settings');
+            TabsStore.trigger('change');
+            break;
         case 'select-tab':
             if (payload.key == 0) { // select tab 0 (+) means create a new tab
                 var tabid = TabsStore.newTab();
@@ -78,8 +83,8 @@ AppDispatcher.register( function(payload) {
                 }
             } else {
                 TabsStore.selectTab(payload.key);
+                TabsStore.trigger('change');
             }
-            TabsStore.trigger('change');
             break;
 
         case 'close-tab':

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -238,6 +238,11 @@ if (process.platform == 'darwin'){
                 {label: "Echo on", click: function(){TabsStore.setEcho(true);}},
                 {label: "Echo off", click: function(){TabsStore.setEcho(false);}},
             ]},
+            {label: "Filter Schemas",
+            submenu: [
+                {label: "Filter on", click: function(){Actions.setSchemaFilter(true);}},
+                {label: "Filter off", click: function(){Actions.setSchemaFilter(false);}},
+            ]},
             {label: "Autocompletion",
             submenu: [
                 {label: "On", click: function(){TabsStore.setAutocompletion(true);}},

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -83,7 +83,12 @@ if (process.platform == 'darwin'){
         {label: "SQL Tabs",
         submenu: [
           { label: "About SQL Tabs",
-            click: function(){Actions.about();}
+            click: Actions.about
+          },
+          {
+            label: 'Preferences',
+            accelerator: 'Command+,',
+            click: Actions.showSettings
           },
           {
             label: 'Hide SQL Tabs',
@@ -105,7 +110,7 @@ if (process.platform == 'darwin'){
           {
             label: 'Quit',
             accelerator: 'Command+Q',
-            click: function(){app.quit()},
+            click: app.quit,
           },
         ]
         },
@@ -113,18 +118,18 @@ if (process.platform == 'darwin'){
         submenu: [
             {label: "Open",
              accelerator: "Command+O",
-             click: function(){openFile();},
+             click: openFile,
             },
             {label: "Save",
              accelerator: "Command+S",
-             click: function(){saveFile();},
+             click: saveFile,
             },
             {label: "Save As",
              accelerator: "Command+Shift+S",
-             click: function(){saveFileAs();},
+             click: saveFileAs,
             },
             {label: "Close File",
-             click: function(){Actions.closeFile()},
+             click: Actions.closeFile,
             },
             {type: 'separator'},
             {label: "Export to JSON",
@@ -140,7 +145,7 @@ if (process.platform == 'darwin'){
             },
             {label: "Close Tab",
              accelerator: "Command+W",
-             click: function(){Actions.close()},
+             click: Actions.close,
             },
         ]
         },
@@ -148,7 +153,7 @@ if (process.platform == 'darwin'){
         submenu: [
             {label: 'Find',
              accelerator: 'Command+F',
-             click: function(){Actions.toggleFindBox()},
+             click: Actions.toggleFindBox,
             },
             {label: 'Undo',
              accelerator: 'Command+Z',
@@ -180,35 +185,35 @@ if (process.platform == 'darwin'){
         {label: "Database",
          submenu:[
             {label: "Database Info",
-             click: function(){Actions.getObjectInfo()},
+             click: Actions.getObjectInfo,
             },
             {label: "Run Script",
              accelerator: "Command+R",
-             click: function(){Actions.execScript()},
+             click: Actions.execScript,
             },
             {label: "Execute Block",
              accelerator: "Command+E",
-             click: function(){Actions.execBlock()},
+             click: Actions.execBlock,
             },
             {label: "Execute All Blocks",
              accelerator: "Command+Shift+E",
-             click: function(){Actions.execAll()},
+             click: Actions.execAll,
             },
             {label: "Break Execution",
              accelerator: "Command+B",
-             click: function(){Actions.cancelQuery()},
+             click: Actions.cancelQuery,
             },
             {label: "Edit connect string",
              accelerator: "Command+L",
-             click: function(){Actions.gotoConnstr()},
+             click: Actions.gotoConnstr,
             },
             {label: "Object Info",
              accelerator: "Command+I",
-             click: function(){Actions.objectInfo()},
+             click: Actions.objectInfo,
             },
             {label: "History",
              accelerator: "Command+Y",
-             click: function(){Actions.toggleHistory()},
+             click: Actions.toggleHistory,
             },
          ]
         },
@@ -252,23 +257,23 @@ if (process.platform == 'darwin'){
         {label: "Window", submenu:[
             {label: "Next Tab",
              accelerator: "Command+]",
-             click: function(){Actions.nextTab()},
+             click: Actions.nextTab
             },
             {label: "Previous Tab",
              accelerator: "Command+[",
-             click: function(){Actions.previosTab();},
+             click: Actions.previosTab
             },
             {label: "Switch Tab View",
              accelerator: "Command+\\",
-             click: function(){Actions.switchView();}
+             click: Actions.switchView
             },
             {label: "Show Project",
              accelerator: "Command+P",
-             click: function(){Actions.showProject();}
+             click: Actions.showProject
             },
             {label: "Hide Project",
              accelerator: "Command+Shift+P",
-             click: function(){Actions.hideProject();}
+             click: Actions.hideProject
             },
         ]
         },

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -145,7 +145,7 @@ if (process.platform == 'darwin'){
             },
             {label: "Close Tab",
              accelerator: "Command+W",
-             click: Actions.close,
+             click: function() {  Actions.close() },
             },
         ]
         },
@@ -185,7 +185,7 @@ if (process.platform == 'darwin'){
         {label: "Database",
          submenu:[
             {label: "Database Info",
-             click: Actions.getObjectInfo,
+             click: function() { Actions.getObjectInfo() },
             },
             {label: "Run Script",
              accelerator: "Command+R",
@@ -219,25 +219,6 @@ if (process.platform == 'darwin'){
         },
         {label: "Options",
         submenu: [
-            {label: "Theme",
-            submenu:[
-                {label: "Dark", click: function(){Actions.setTheme("dark");}},
-                {label: "Bright", click: function(){Actions.setTheme("bright");}},
-            ]},
-            {label: "Mode",
-            submenu: [
-                {label: "Classic", click: function(){Actions.setMode("classic");}},
-                {label: "Vim", click: function(){Actions.setMode("vim");}},
-            ]},
-            {label: "Font",
-            submenu: [
-                {label: "X-Small", click: function(){setFontSize("x-small");}},
-                {label: "Small", click: function(){setFontSize("small");}},
-                {label: "Medium", click: function(){setFontSize("medium");}},
-                {label: "Large", click: function(){setFontSize("large");}},
-                {label: "X-Large", click: function(){setFontSize("x-large");}},
-                {label: "XX-Large", click: function(){setFontSize("xx-large");}},
-            ]},
             {label: "Output",
             submenu: [
                 {label: "Echo on", click: function(){TabsStore.setEcho(true);}},

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -72,11 +72,6 @@ var exportResult = function(format){
 }
 
 
-
-var setFontSize = function(size){
-    Actions.setFontSize(size);
-}
-
 if (process.platform == 'darwin'){
 
     var template = [
@@ -217,24 +212,6 @@ if (process.platform == 'darwin'){
             },
          ]
         },
-        {label: "Options",
-        submenu: [
-            {label: "Output",
-            submenu: [
-                {label: "Echo on", click: function(){TabsStore.setEcho(true);}},
-                {label: "Echo off", click: function(){TabsStore.setEcho(false);}},
-            ]},
-            {label: "Filter Schemas",
-            submenu: [
-                {label: "Filter on", click: function(){Actions.setSchemaFilter(true);}},
-                {label: "Filter off", click: function(){Actions.setSchemaFilter(false);}},
-            ]},
-            {label: "Autocompletion",
-            submenu: [
-                {label: "On", click: function(){TabsStore.setAutocompletion(true);}},
-                {label: "Off", click: function(){TabsStore.setAutocompletion(false);}},
-            ]},
-        ]},
         {label: "Window", submenu:[
             {label: "Next Tab",
              accelerator: "Command+]",
@@ -351,40 +328,6 @@ if (process.platform == 'darwin'){
          ]
         },
 
-        {label: "Options",
-        submenu: [
-            {label: "Theme",
-            submenu:[
-                {label: "Dark", click: function(){Actions.setTheme("dark");}},
-                {label: "Bright", click: function(){Actions.setTheme("bright");}},
-            ]},
-            {label: "Mode",
-            submenu: [
-                {label: "Classic", click: function(){Actions.setMode("classic");}},
-                {label: "Vim", click: function(){Actions.setMode("vim");}},
-            ]},
-            {label: "Font",
-            submenu: [
-                {label: "X-Small", click: function(){setFontSize("x-small");}},
-                {label: "Small", click: function(){setFontSize("small");}},
-                {label: "Medium", click: function(){setFontSize("medium");}},
-                {label: "Large", click: function(){setFontSize("large");}},
-                {label: "X-Large", click: function(){setFontSize("x-large");}},
-                {label: "XX-Large", click: function(){setFontSize("xx-large");}},
-            ]},
-            {label: "Output",
-            submenu: [
-                {label: "Echo on", click: function(){TabsStore.setEcho(true);}},
-                {label: "Echo off", click: function(){TabsStore.setEcho(false);}},
-            ]},
-            {label: "Autocompletion",
-            submenu: [
-                {label: "On", click: function(){TabsStore.setAutocompletion(true);}},
-                {label: "Off", click: function(){TabsStore.setAutocompletion(false);}},
-            ]},
-        ]},
-
-
         {label: "Window", submenu:[
             {label: "Next Tab",
              accelerator: "Ctrl+Tab",
@@ -411,6 +354,11 @@ if (process.platform == 'darwin'){
         },
 
         {label: "Help", submenu:[
+            {
+                label: 'Preferences',
+                accelerator: 'Ctrl+,',
+                click: Actions.showSettings
+            },
             {label: "About",
              click: function(){Actions.about()},
             }

--- a/src/ObjectInfo.js
+++ b/src/ObjectInfo.js
@@ -82,7 +82,11 @@ var ObjectInfo = React.createClass({
 
     filterSchemas: function(item){
          if (TabsStore.schemaFilter) {
-             return item.indexOf('temp') === -1;
+             if (TabsStore.schemaFilterMode === 'white') {
+                 return TabsStore.schemaFilterCompiledRegEx.test(item);
+             } else {
+                 return !TabsStore.schemaFilterCompiledRegEx.test(item);
+             }
          }
          return true;
     },

--- a/src/ObjectInfo.js
+++ b/src/ObjectInfo.js
@@ -39,6 +39,7 @@ var ObjectInfo = React.createClass({
     componentDidMount: function(){
 
         TabsStore.bind('change-theme', this.changeThemeHandler);
+        TabsStore.bind('change-schema-filter', this.changeSchemaFilter);
 
         if (this.scripts.length > 0){
 
@@ -71,6 +72,19 @@ var ObjectInfo = React.createClass({
         if (typeof(this.editor) != 'undefined'){
             this.editor.setTheme('ace/theme/' + TabsStore.getEditorTheme());
         }
+    },
+
+    changeSchemaFilter: function(){
+        if (this.props.info.object_type == 'database') {
+            this.forceUpdate();
+        }
+    },
+
+    filterSchemas: function(item){
+         if (TabsStore.schemaFilter) {
+             return item.indexOf('temp') === -1;
+         }
+         return true;
     },
 
     getInfo: function(object){
@@ -196,7 +210,7 @@ var ObjectInfo = React.createClass({
                     '#output-console-'+self.props.eventKey, "#output-console-"+self.props.eventKey
                     )}}><span className="glyphicon glyphicon-circle-arrow-up"/></a>;
 
-        var schemas = info.object.schemas.map(function(item, idx){
+        var schemas = info.object.schemas.filter(this.filterSchemas).map(function(item, idx){
             var id = "schema_"+self.props.eventKey+"_"+idx;
             return <li key={id}><a href="#" onClick={function(){self.getInfo(item+'.');}}>{item}</a></li>
         });

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2015  Aliaksandr Aliashkevich
-  
+
       This program is free software: you can redistribute it and/or modify
       it under the terms of the GNU General Public License as published by
       the Free Software Foundation, either version 3 of the License, or
@@ -16,14 +16,103 @@
 */
 
 var React = require('react');
+var Actions = require('./Actions');
+var TabsStore = require('./TabsStore');
 
 var Settings = React.createClass({
 
-    render: function(){
+    getInitialState: function(){
+        return {
+            theme: TabsStore.theme,
+            mode: TabsStore.mode,
+            fontSize: TabsStore.fontSize,
+        };
+    },
+
+    componentDidMount: function() {
+        TabsStore.bind('change-theme', this.storeChangedHandler);
+        TabsStore.bind('change-mode', this.storeChangedHandler);
+        TabsStore.bind('font-size-changed', this.storeChangedHandler);
+    },
+
+    componentWillUnmount: function() {
+        TabsStore.unbind('change-theme', this.storeChangedHandler);
+        TabsStore.unbind('change-mode', this.storeChangedHandler);
+        TabsStore.unbind('font-size-changed', this.storeChangedHandler);
+    },
+
+    storeChangedHandler: function(){
+        this.setState({
+            theme: TabsStore.theme,
+            mode: TabsStore.mode,
+            fontSize: TabsStore.fontSize,
+        });
+    },
+
+    setTheme(ev) {
+        Actions.setTheme(ev.target.value);
+    },
+
+    setMode(ev) {
+        Actions.setMode(ev.target.value);
+    },
+
+    setFontSize(ev) {
+        Actions.setFontSize(ev.target.value);
+    },
+
+    setEcho(ev) {
+        TabsStore.setEcho(ev.target.checked);
+    },
+
+    render(){
 
         return (
-            <div className="settings-page">
-                This is the settings page
+            <div style={{padding: '30px'}}>
+                <h1>Settings</h1>
+                <div className="form-group">
+                    <label htmlFor="theme-select">Theme</label>
+                    <select id="theme-select" className="form-control" value={this.state.theme} onChange={this.setTheme}>
+                        <option value="dark">Dark</option>
+                        <option value="bright">Bright</option>
+                    </select>
+                </div>
+                <div className="form-group">
+                    <label htmlFor="mode-select">Mode</label>
+                    <select id="mode-select" className="form-control" value={this.state.mode} onChange={this.setMode}>
+                        <option value="classic">Classic</option>
+                        <option value="vim">Vim</option>
+                    </select>
+                </div>
+                <div className="form-group">
+                    <label htmlFor="font-select">Font</label>
+                    <select id="font-select" className="form-control" value={this.state.fontSize} onChange={this.setFontSize}>
+                        <option value="x-small">X-Small</option>
+                        <option value="small">Small</option>
+                        <option value="medium">Medium</option>
+                        <option value="large">Large</option>
+                        <option value="x-large">X-Large</option>
+                        <option value="xx-large">XX-Large</option>
+                    </select>
+                </div>
+                <div className="checkbox">
+                    <label>
+                        <input type="checkbox" value="true" checked={this.state.showQuery} onChange={this.setEcho} />
+                        Output echo
+                    </label>
+                </div>
+                <div className="checkbox">
+                    <label>
+                        <input type="checkbox" value="option1" />
+                        Enable filter
+                    </label>
+                </div>
+                <div className="checkbox">
+                    <label>
+                        <input type="checkbox" value="option1" />
+                        Auto-completation
+                    </label>
+                </div>
             </div>
         )
 

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -56,40 +56,39 @@ var Settings = React.createClass({
         TabsStore.unbind('change-schema-filter', this.storeChangedHandler);
     },
 
-    setTheme(ev) {
+    setTheme: function(ev) {
         Actions.setTheme(ev.target.value);
     },
 
-    setMode(ev) {
+    setMode: function(ev) {
         Actions.setMode(ev.target.value);
     },
 
-    setFontSize(ev) {
+    setFontSize: function(ev) {
         Actions.setFontSize(ev.target.value);
     },
 
-    setSchemaFilterMode(ev) {
+    setSchemaFilterMode: function(ev) {
         Actions.setSchemaFilterMode(ev.target.value);
     },
 
-    setSchemaFilterRegEx(ev) {
+    setSchemaFilterRegEx: function(ev) {
         Actions.setSchemaFilterRegEx(ev.target.value);
     },
 
-    setEcho(ev) {
+    setEcho: function(ev) {
         TabsStore.setEcho(ev.target.checked);
     },
 
-    setAutoCompletion(ev) {
+    setAutoCompletion: function(ev) {
         TabsStore.setAutocompletion(ev.target.checked);
     },
 
-    enableSchemaFilter(ev) {
+    enableSchemaFilter: function(ev) {
         Actions.enableSchemaFilter(ev.target.checked);
     },
 
-    getSchemaFilterAdvanced() {
-        console.log(this.state);
+    getSchemaFilterAdvanced: function() {
         if (this.state.schemaFilter) {
             return (
                 <blockquote>
@@ -106,7 +105,7 @@ var Settings = React.createClass({
         return null
     },
 
-    render(){
+    render: function(){
 
         return (
             <div style={{padding: '30px'}}>

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -26,27 +26,34 @@ var Settings = React.createClass({
             theme: TabsStore.theme,
             mode: TabsStore.mode,
             fontSize: TabsStore.fontSize,
+            showQuery: TabsStore.showQuery,
+            autoCompletion: TabsStore.auto_completion,
+            schemaFilter: TabsStore.schemaFilter,
+            schemaFilterMode: TabsStore.schemaFilterMode,
+            schemaFilterRegEx: TabsStore.schemaFilterRegEx,
         };
+    },
+
+    storeChangedHandler: function(){
+        this.setState(this.getInitialState());
     },
 
     componentDidMount: function() {
         TabsStore.bind('change-theme', this.storeChangedHandler);
         TabsStore.bind('change-mode', this.storeChangedHandler);
         TabsStore.bind('font-size-changed', this.storeChangedHandler);
+        TabsStore.bind('change-show-query', this.storeChangedHandler);
+        TabsStore.bind('change-auto-completion', this.storeChangedHandler);
+        TabsStore.bind('change-schema-filter', this.storeChangedHandler);
     },
 
     componentWillUnmount: function() {
         TabsStore.unbind('change-theme', this.storeChangedHandler);
         TabsStore.unbind('change-mode', this.storeChangedHandler);
         TabsStore.unbind('font-size-changed', this.storeChangedHandler);
-    },
-
-    storeChangedHandler: function(){
-        this.setState({
-            theme: TabsStore.theme,
-            mode: TabsStore.mode,
-            fontSize: TabsStore.fontSize,
-        });
+        TabsStore.unbind('change-show-query', this.storeChangedHandler);
+        TabsStore.unbind('change-auto-completion', this.storeChangedHandler);
+        TabsStore.unbind('change-schema-filter', this.storeChangedHandler);
     },
 
     setTheme(ev) {
@@ -61,8 +68,42 @@ var Settings = React.createClass({
         Actions.setFontSize(ev.target.value);
     },
 
+    setSchemaFilterMode(ev) {
+        Actions.setSchemaFilterMode(ev.target.value);
+    },
+
+    setSchemaFilterRegEx(ev) {
+        Actions.setSchemaFilterRegEx(ev.target.value);
+    },
+
     setEcho(ev) {
         TabsStore.setEcho(ev.target.checked);
+    },
+
+    setAutoCompletion(ev) {
+        TabsStore.setAutocompletion(ev.target.checked);
+    },
+
+    enableSchemaFilter(ev) {
+        Actions.enableSchemaFilter(ev.target.checked);
+    },
+
+    getSchemaFilterAdvanced() {
+        console.log(this.state);
+        if (this.state.schemaFilter) {
+            return (
+                <blockquote>
+                    <label htmlFor="schema-filter-mode-select">Filter mode</label>
+                    <select id="schema-filter-mode-select" className="form-control" value={this.state.schemaFilterMode} onChange={this.setSchemaFilterMode}>
+                        <option value="white">Whitelist</option>
+                        <option value="black">Blacklist</option>
+                    </select>
+                    <label htmlFor="schema-filter-regex-input">Filter regex</label>
+                    <input type="text" className="form-control" placeholder=".*text.*" value={this.state.schemaFilterRegEx} onChange={this.setSchemaFilterRegEx}/>
+                </blockquote>
+            )
+        }
+        return null
     },
 
     render(){
@@ -103,13 +144,14 @@ var Settings = React.createClass({
                 </div>
                 <div className="checkbox">
                     <label>
-                        <input type="checkbox" value="option1" />
-                        Enable filter
+                        <input type="checkbox" value="true" checked={this.state.schemaFilter} onChange={this.enableSchemaFilter} />
+                        Enable schema filter
                     </label>
                 </div>
+                {this.getSchemaFilterAdvanced()}
                 <div className="checkbox">
                     <label>
-                        <input type="checkbox" value="option1" />
+                        <input type="checkbox" value="true" checked={this.state.autoCompletion} onChange={this.setAutoCompletion} />
                         Auto-completation
                     </label>
                 </div>

--- a/src/Settings.js
+++ b/src/Settings.js
@@ -1,0 +1,33 @@
+/*
+  Copyright (C) 2015  Aliaksandr Aliashkevich
+  
+      This program is free software: you can redistribute it and/or modify
+      it under the terms of the GNU General Public License as published by
+      the Free Software Foundation, either version 3 of the License, or
+      (at your option) any later version.
+
+      This program is distributed in the hope that it will be useful,
+      but WITHOUT ANY WARRANTY; without even the implied warranty of
+      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+      GNU General Public License for more details.
+
+      You should have received a copy of the GNU General Public License
+      along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+var React = require('react');
+
+var Settings = React.createClass({
+
+    render: function(){
+
+        return (
+            <div className="settings-page">
+                This is the settings page
+            </div>
+        )
+
+    }
+});
+
+module.exports = Settings;

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -23,6 +23,7 @@ var TabSplit = require('./TabSplit');
 var Editor = require('./Editor');
 var TabToolbar = require('./TabToolbar');
 var SearchBox = require('./SearchBox');
+var Settings = require('./Settings');
 var Project = require('./Project');
 
 var TabContent = React.createClass({
@@ -51,6 +52,16 @@ var TabContent = React.createClass({
     render: function(){
 
         var cls = (this.props.visible) ? 'tab-content': 'tab-content hidden';
+        var isSettings = TabsStore.getConnstr(this.props.eventKey) === 'about:settings'
+
+        if (isSettings) {
+            return (
+
+              <div className={cls}>
+                  <Settings theme={this.state.theme} />
+              </div>
+            )
+        }
 
         return (
 

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -36,11 +36,11 @@ var TabContent = React.createClass({
     },
 
     componentDidMount: function() {  
-        TabsStore.bind('change', this.storeChangedHandler);
+        TabsStore.bind('change-theme', this.storeChangedHandler);
     },
 
     componentWillUnmount: function() {  
-        TabsStore.unbind('change', this.storeChangedHandler);
+        TabsStore.unbind('change-theme', this.storeChangedHandler);
     },
 
     storeChangedHandler: function(){
@@ -58,7 +58,7 @@ var TabContent = React.createClass({
             return (
 
               <div className={cls}>
-                  <Settings theme={this.state.theme} />
+                  <Settings />
               </div>
             )
         }

--- a/src/TabsStore.js
+++ b/src/TabsStore.js
@@ -101,9 +101,9 @@ var _TabsStore = function(){
     }
 
     this.newTab = function(connstr){
-        if (typeof(connstr) == 'undefined'){
+        if (typeof(connstr) === 'undefined'){
             connstr = this.getConnstr(this.selectedTab);
-            if (connstr.startsWith('about:')) {
+            if (typeof connstr === 'string' && connstr.startsWith('about:')) {
                 connstr = ''
             }
         }
@@ -179,9 +179,18 @@ var _TabsStore = function(){
         this.mode = mode;
     };
 
-    this.setSchemaFilter = function (schemaFilter) {
+    this.enableSchemaFilter = function (schemaFilter) {
         this.schemaFilter = schemaFilter;
-    },
+    }
+
+    this.setSchemaFilterMode = function (mode) {
+        this.schemaFilterMode = mode;
+    }
+
+    this.setSchemaFilterRegex = function (regex) {
+        this.schemaFilterRegEx = regex;
+        this.schemaFilterCompiledRegEx = new RegExp(regex, 'i');
+    }
 
     this.getEditorMode = function(){
         if (this.mode == 'vim'){
@@ -380,6 +389,7 @@ var _TabsStore = function(){
 
     this.setEcho = function(boolean_echo){
         this.showQuery = boolean_echo;
+        this.trigger('change-show-query')
     }
 
     this.exportResult = function(filename, format){
@@ -425,6 +435,7 @@ var _TabsStore = function(){
 
     this.setAutocompletion = function(auto_completion){
         this.auto_completion = auto_completion;
+        this.trigger('change-auto-completion');
         Config.saveAutoCompletion(auto_completion);
     }
 

--- a/src/TabsStore.js
+++ b/src/TabsStore.js
@@ -86,6 +86,20 @@ var _TabsStore = function(){
 
     this.getAll = function(){return this.tabs;};
 
+    this.getAllAsArray = function () {
+        return this.order.map(function (key) { return this.tabs[key];}, this)
+    }
+
+    this.findIndexByProperty = function (property, value) {
+        var indexOnOrder = this.getAllAsArray().findIndex(function (tab) {
+            return tab[property] == value
+        })
+        if (indexOnOrder === -1) {
+            return -1
+        }
+        return this.order[indexOnOrder]
+    }
+
     this.newTab = function(connstr){
         if (typeof(connstr) == 'undefined'){
             connstr = this.getConnstr(this.selectedTab);

--- a/src/TabsStore.js
+++ b/src/TabsStore.js
@@ -162,6 +162,10 @@ var _TabsStore = function(){
         this.mode = mode;
     };
 
+    this.setSchemaFilter = function (schemaFilter) {
+        this.schemaFilter = schemaFilter;
+    },
+
     this.getEditorMode = function(){
         if (this.mode == 'vim'){
             return 'ace/keyboard/vim';

--- a/src/TabsStore.js
+++ b/src/TabsStore.js
@@ -46,24 +46,24 @@ var Tab = function(id, connstr){
 
     this.getTitle = function(){
         if (this.filename != null){
-            var ret = this.filename;
+            return this.filename;
         } else {
             if (typeof(this.connstr) != 'undefined' && this.connstr != null) {
 
                     if (this.connstr.indexOf('---') != -1){ // show alias
-                        var ret = '[ '+this.connstr.match(/---\s*(.*)/)[1]+' ]';
+                       return '[ '+this.connstr.match(/---\s*(.*)/)[1]+' ]';
+                    } else if (this.connstr.startsWith('about:')) {
+                        return this.connstr[6].toUpperCase() + this.connstr.substr(7).toLowerCase()
                     } else {
                         if (this.connstr.length > 30){ // cut too long connstr
-                            var ret = '[...'+this.connstr.substr(this.connstr.length-20)+' ]';
+                           return '[...'+this.connstr.substr(this.connstr.length-20)+' ]';
                         } else {
-                            var ret = '[ '+this.connstr+' ]';
+                           return '[ '+this.connstr+' ]';
                         }
                     }
-            } else {
-                return '';
             }
         }
-        return ret;
+        return '';
     }
 };
 
@@ -89,6 +89,9 @@ var _TabsStore = function(){
     this.newTab = function(connstr){
         if (typeof(connstr) == 'undefined'){
             connstr = this.getConnstr(this.selectedTab);
+            if (connstr.startsWith('about:')) {
+                connstr = ''
+            }
         }
         if (this.selectedTab > 0) {
             password = this.tabs[this.selectedTab].password;


### PR DESCRIPTION
I've created a settings page ( like the Atom one ).

The settings page appears if you digit on the connection string "about:settings" or if you open it from the menu.
In case you open from the menu it will check if one is already open (I tried to make possible to have only 1 settings tab open, even if more than 1 doesn't conflict).

I made some minor changes:

- If you press CMD+W, before closing a tab will require a confirmation (a lot of times to me happen to press CMD+W instead of CMD+E)
- Schema filtering like the other Pull Request but:
  - The schema filter accept a mode (Whitelist | Blacklist)
  - The schema filter accept a regexp (case insensitive)
- I add the build scripts to the npm scripts, in this way is possible to build the app without installing electron-packager globally (or the other packages)

<img width="1109" alt="screen shot 2017-03-17 at 23 21 42" src="https://cloud.githubusercontent.com/assets/4061875/24066331/7774ec24-0b69-11e7-8d17-64e8c2bdfb65.png">
