### PR TITLE
Open Postgres links

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -21,5 +21,16 @@
                         <string>SQLDocument</string>
                 </dict>
         </array>
+        <key>CFBundleURLTypes</key>
+        <array>
+            <dict>
+                <key>CFBundleURLName</key>
+                <string>Postgres Database</string>
+                <key>CFBundleURLSchemes</key>
+                <array>
+                    <string>postgres</string>
+                </array>
+             </dict>
+        </array>
 </dict>
 </plist>

--- a/mac_build.sh
+++ b/mac_build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 rm -rf .build
 mkdir .build
 npm install
@@ -13,6 +13,6 @@ cp -r css .build/
 cp -r node_modules .build/
 
 cd .build
-electron-packager ./ "SQL Tabs" --platform=darwin --arch=x64 --electron-version=1.4.7 --icon logo.icns --asar --prune --extend-info ../Info.plist --extra-resource ../logo_sql.icns
+electron-packager ./ "SQL Tabs" --platform=darwin --arch=x64 --electron-version=1.4.7 --icon logo.icns --asar --prune --extend-info ../Info.plist --extra-resource ../logo_sql.icns --protocol postgres ---procol-name postgres
 cd ..
 

--- a/main.js
+++ b/main.js
@@ -27,6 +27,7 @@ var app = electron.app;
 var BrowserWindow = electron.BrowserWindow;
 
 var mainWindow = null;
+var urlToOpen = null;
 var files2open = [];
 
 var createWindow = function(){
@@ -70,5 +71,32 @@ app.on('ready', function() {
             var emit_open_file = getEmitter(contents, path);
             contents.on('did-finish-load', emit_open_file);
         }
+    }
+    if (urlToOpen) {
+        mainWindow.webContents.on('did-finish-load', function () {
+            mainWindow.webContents.send('open-url', urlToOpen);
+        });
+    }
+
+    if (!app.isDefaultProtocolClient('postgres')) {
+        electron.dialog.showMessageBox({
+            type: 'question',
+            buttons: ['Yes', 'No'],
+            cancelId: 1,
+            message: 'Do you want to set SQL Tabs as the default postgres client?'
+        }, function (button) {
+            if (button === 0 ) {
+                app.setAsDefaultProtocolClient('postgres');
+            }
+        })
+    }
+});
+
+app.on('open-url', function (ev, url) {
+    ev.preventDefault();
+    if (app.isReady()) {
+        mainWindow.webContents.send('open-url', url);
+    } else {
+        urlToOpen = url;
     }
 });

--- a/src/Actions.js
+++ b/src/Actions.js
@@ -82,11 +82,12 @@ var Actions = {
         });
     },
 
-    newTab: function(script, filename){
+    newTab: function(script, filename, connstr){
         AppDispatcher.dispatch({
             eventName: 'select-tab',
             key: 0,
             script: script,
+            connstr: connstr,
             filename: filename,
         });
     },

--- a/src/App.js
+++ b/src/App.js
@@ -36,6 +36,10 @@ require('electron').ipcRenderer.on('open-file', function(event, path) {
     }
 })
 
+require('electron').ipcRenderer.on('open-url', function(event, url) {
+    Actions.newTab(null, null, url);
+})
+
 require('./Menu');
 
 var mountNode = document.body;

--- a/src/Dispatcher.js
+++ b/src/Dispatcher.js
@@ -69,7 +69,7 @@ AppDispatcher.register( function(payload) {
     switch( payload.eventName ) {
         case 'select-tab':
             if (payload.key == 0) { // select tab 0 (+) means create a new tab
-                var tabid = TabsStore.newTab();
+                var tabid = TabsStore.newTab(payload.connstr);
                 TabsStore.tmpScript = payload.script;
                 TabsStore.trigger('change');
                 if (payload.filename){


### PR DESCRIPTION
After opening the app the first time, the app will ask if you want to use SQL Tabs to open postgres:// links.
When you click on one of those links on chrome, chrome will ask you if you want to open the link with SQL Tabs.
On Mac, if you run on the terminal "open postgres://..." will open SQL Tabs.

In both cases, if SQL Tabs is already open, the link will be open in a new tab

This PR relates to https://github.com/sasha-alias/sqltabs/issues/71