### PR TITLE
parse mssql options from query string

### DIFF
--- a/src/connectors/mssql/Database.js
+++ b/src/connectors/mssql/Database.js
@@ -29,14 +29,23 @@ var parse_connstr = function(connstr){
         var password = '';
     }
 
-
     var config = {
         user: user,
         password: password,
         server: parsed.hostname,
         port: parsed.port,
-        options: {},
     };
+
+    // parse options
+    if (parsed.query != null) {
+      parsed.query.split('&').forEach(function(pair) {
+        kv = pair.split('=');
+        if (kv.length == 2) {
+          config[kv[0]] = kv[1];
+        }
+      });
+    }
+
     return config
 }
 


### PR DESCRIPTION
I needed to set the requestTimeout for a long running query but it seemed to me from the source that this options were being ignored.   I'm not a node developer so couldn't figure out your tests but I did run a few manual tests on it.  Thanks for an awesome sql client!